### PR TITLE
Replace the deprecated scipy.misc with scipy.special

### DIFF
--- a/bayesloop/core.py
+++ b/bayesloop/core.py
@@ -12,8 +12,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 from scipy.optimize import minimize
-from scipy.misc import factorial
-from scipy.misc import logsumexp
+from scipy.special import factorial
+from scipy.special import logsumexp
 from scipy.special import beta as beta_func
 import sympy.abc as abc
 from sympy import Symbol

--- a/bayesloop/observationModels.py
+++ b/bayesloop/observationModels.py
@@ -12,7 +12,7 @@ import sympy.abc as abc
 from sympy import lambdify
 from sympy.stats import density
 from .jeffreys import getJeffreysPrior
-from scipy.misc import factorial
+from scipy.special import factorial
 from scipy.special import iv
 from .exceptions import ConfigurationError, PostProcessingError
 from .helper import cint, oint, freeSymbols


### PR DESCRIPTION
`factorial` and `logsumexp` is moved from `scipy.misc` to `scipy.special`

Details: https://scipy.github.io/devdocs/release.1.3.0.html#scipy-interpolate-changes